### PR TITLE
PR 테스트 겸!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Files in build folder
+build/*
+
+# Settings for VisualStudio Code
+.vscode/*
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required (VERSION 3.1)
+project (ioniq_lon_control)
+
+set (CMAKE_CXX_STANDARD 11)
+
+find_package(Boost REQUIRED COMPONENTS system thread chrono)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+  link_directories(${Boost_LIBRARY_DIRS})
+endif(Boost_FOUND)
+
+set(BOOST_LIBS ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_CHRONO_LIBRARY})
+
+include_directories(include)
+
+add_subdirectory(src)

--- a/include/can_mac_val.h
+++ b/include/can_mac_val.h
@@ -2,6 +2,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
+#include <memory>
 
 //#define PCAN_CHANNEL PCAN_USBBUS1
 //#define PCAN_BAUDRATE PCAN_BAUD_500K
@@ -33,6 +34,8 @@ public:
     unsigned char data[CAN_MAX_DLEN];   // peakcan과 같음
 };
 
+class CAN_AVL;
+typedef std::shared_ptr<CAN_AVL> CAN_AVLPtr;
 class CAN_AVL
 {
 public:
@@ -58,6 +61,8 @@ public:
 CAN_AVL::CAN_AVL(TPCANHandle dev_name_, TPCANHandle dev_baud_rate_)
 {
     CAN_INIT(dev_name_, dev_baud_rate_);
+    memset(&message, 0, sizeof(TPCANMsg));
+
 }
 
 void CAN_AVL::CAN_INIT(TPCANHandle dev_name_, TPCANHandle dev_baud_rate_)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required (VERSION 2.8.11)
+project (ioniq_lon_control)
+
+find_package(Boost REQUIRED COMPONENTS thread system)
+IF(Boost_FOUND)
+  INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
+  LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
+ENDIF(Boost_FOUND)
+
+SET(USED_LIBS ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
+
+add_executable(control_main control_main_timer.cpp)
+target_link_libraries(control_main ${USED_LIBS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-#add_executable(control_main src/control_main.cpp)
-#target_link_libraries(control_main ${BOOST_LIBS})
+add_executable(control_main src/control_main.cpp)
+target_link_libraries(control_main ${BOOST_LIBS})
 
 add_executable(timer_example timer_example.cpp)
 target_link_libraries(timer_example ${BOOST_LIBS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,18 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.1)
+set (CMAKE_CXX_STANDARD 11)
+
 project (ioniq_lon_control)
 
-find_package(Boost REQUIRED COMPONENTS thread system)
+find_package(Boost REQUIRED COMPONENTS system thread chrono)
 IF(Boost_FOUND)
   INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
   LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
 ENDIF(Boost_FOUND)
 
-SET(USED_LIBS ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
+SET(USED_LIBS ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_CHRONO_LIBRARY})
 
-add_executable(control_main control_main_timer.cpp)
+add_executable(control_main control_main.cpp)
 target_link_libraries(control_main ${USED_LIBS})
+
+add_executable(timer_example timer_example.cpp)
+target_link_libraries(timer_example ${USED_LIBS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,5 @@
-cmake_minimum_required (VERSION 3.1)
-set (CMAKE_CXX_STANDARD 11)
-
-project (ioniq_lon_control)
-
-find_package(Boost REQUIRED COMPONENTS system thread chrono)
-IF(Boost_FOUND)
-  INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
-  LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
-ENDIF(Boost_FOUND)
-
-SET(USED_LIBS ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_CHRONO_LIBRARY})
-
-add_executable(control_main control_main.cpp)
-target_link_libraries(control_main ${USED_LIBS})
+#add_executable(control_main src/control_main.cpp)
+#target_link_libraries(control_main ${BOOST_LIBS})
 
 add_executable(timer_example timer_example.cpp)
-target_link_libraries(timer_example ${USED_LIBS})
+target_link_libraries(timer_example ${BOOST_LIBS})

--- a/src/control_main.cpp
+++ b/src/control_main.cpp
@@ -108,7 +108,14 @@ int main()
 
     while(running)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::cout << "Put target speed and press enter : ";
+        std::cin >> target_vehicle_speed;
+        if(target_vehicle_speed < 0 || target_vehicle_speed >100)
+        {
+            target_vehicle_speed = 0;
+            std::cout << "invalid input, setting target speed to 0.\n";
+        }
+        //std::this_thread::sleep_for(std::chrono::milliseconds(10));
         if(can_error_flag == true)
         {
             running = false;

--- a/src/timer.h
+++ b/src/timer.h
@@ -8,13 +8,13 @@
 #include <iostream>
 
 
+
 struct timer
 {
     timer(unsigned int delay, boost::asio::io_service* s_service, boost::function< void () > callback) :
     m_timer(*s_service),
     m_callback(callback),
-    m_delay(delay),
-    s_counter(0)
+    m_delay(delay)
     {
     }
 
@@ -39,7 +39,6 @@ struct timer
         m_callback();
     }
 
-    unsigned int s_counter;
     boost::asio::deadline_timer m_timer;
     boost::function< void () > m_callback;
     unsigned int m_delay;

--- a/src/timer.h
+++ b/src/timer.h
@@ -1,0 +1,49 @@
+#ifndef __TIMER__H__
+#define __TIMER__H__
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/function.hpp>
+#include <boost/bind.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <iostream>
+
+
+struct timer
+{
+    timer(unsigned int delay, boost::asio::io_service* s_service, boost::function< void () > callback) :
+    m_timer(*s_service),
+    m_callback(callback),
+    m_delay(delay),
+    s_counter(0)
+    {
+    }
+
+    void start()
+    {
+        m_timeBase = boost::posix_time::microsec_clock::universal_time();
+        do_start();
+    }
+
+    void do_start()
+    {
+        m_elapsed = boost::posix_time::microsec_clock::universal_time() - m_timeBase;
+        m_timer.expires_from_now(m_estimated - m_elapsed +
+        boost::posix_time::millisec(m_delay));
+        m_timer.async_wait(boost::bind(&timer::handle_wait, this, _1));
+    }
+
+    void handle_wait(const boost::system::error_code& e)
+    {
+        m_estimated += boost::posix_time::millisec(m_delay);
+        do_start();
+        m_callback();
+    }
+
+    unsigned int s_counter;
+    boost::asio::deadline_timer m_timer;
+    boost::function< void () > m_callback;
+    unsigned int m_delay;
+    boost::posix_time::ptime m_timeBase;
+    boost::posix_time::time_duration m_estimated, m_elapsed;
+};
+#endif

--- a/src/timer_example.cpp
+++ b/src/timer_example.cpp
@@ -1,0 +1,31 @@
+#include <boost/asio/io_service.hpp>
+#include <boost/chrono.hpp>
+#include <boost/thread.hpp>
+
+#include <iostream>
+
+#include "timer.h"
+
+using namespace boost::chrono;
+static high_resolution_clock::time_point start;
+
+static microseconds us;
+
+void timerCallback()
+{
+  us = duration_cast<boost::chrono::microseconds> (boost::chrono::high_resolution_clock::now() - start);
+  std::cout << "timer took " << us.count() << "us " << "\n";
+  start = high_resolution_clock::now();
+}
+
+int main()
+{
+  boost::asio::io_service service;
+
+  timer t2(20, &service, timerCallback);
+
+  start = high_resolution_clock::now();
+  t2.start();
+
+  service.run();
+} 


### PR DESCRIPTION
#### 주 변경 사항
1. pthread에서 std::thread로 변경
 - C-style code에서는 크게 문제 없으나 향후 class를 적극 활용하기 위해 바꾸는게 좋다는 생각.
 - 서로 다른 thread에서 접근하는 변수에는 mutex로 감싸두는게 반드시 필요!(PR하고 생각났는데 cin으로 target_vehicle_speed 설정하는 부분에 안했다...)
2. PD제어 위치 변경
 - main thread의 while loop 에서 거의 1us주기로 계산중이어서 write시점으로 제어 계산 코드 위치를 변경함.
 - 이전 코드에서 제어 명령이 20ms 주기로 전달되었는지 확인 필요. 
 - 현재 구현한 것 처럼 명시적으로 제어 주기(delta_t)를 변수로 두지 않는 형태로 제어기를 짰을 때는 가능하면 고정 주기를 보장해두고 게인 튜닝을 하는 것이 좋음.

#### 그 외
 - boost::asio에 있는 io_service로 구현할 수 있는 타이머를 가지고 주기 메시지를 날려보려 했는데... boost와 std호환도 어렵고 코드 복잡도만 높아지는 것 같아 보류.
 - control_main.cpp에 구현한 내용을 CAN_AVL에 좀 더 넣어두는게 좋을 것 같음. CAN_AVL을 상속받는 ControlCAN class를 만들어 Mo_Val()같은걸 넣어버리거나?
